### PR TITLE
Updated example for correctness; simpler boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/VojtechVitek/go-trello"
 )
 
 func main() {
 	// New Trello Client
-	trello, err := trello.NewAuthClient("application-key", "token")
+	appKey := "application-key"
+	token := "token"
+	trello, err := trello.NewAuthClient(appKey, &token)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -59,6 +63,7 @@ func main() {
 			}
 		}
 	}
+}
 ```
 
 prints

--- a/member.go
+++ b/member.go
@@ -18,6 +18,7 @@ package trello
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 type Member struct {
@@ -57,7 +58,7 @@ type Member struct {
 }
 
 func (c *Client) Member(nick string) (member *Member, err error) {
-	body, err := c.Get("/member/" + nick)
+	body, err := c.Get("/members/" + nick)
 	if err != nil {
 		return
 	}
@@ -67,8 +68,15 @@ func (c *Client) Member(nick string) (member *Member, err error) {
 	return
 }
 
-func (m *Member) Boards() (boards []Board, err error) {
-	body, err := m.client.Get("/member/" + m.Id + "/boards")
+func (m *Member) Boards(field ...string) (boards []Board, err error) {
+	fields := ""
+	if len(field) == 0 {
+		fields = "all"
+	} else {
+		fields = strings.Join(field, ",")
+	}
+
+	body, err := m.client.Get("/members/" + m.Id + "/boards?fields=" + fields)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The example shown in the readme, incorrectly showed 2 strings passed when it should be a string and a string pointer.

Additionally on 'larger' boards, the `/members/[id]/boards` blew up. It's easier to request only the name and shortUrl fields by default, since that's all we're using 99% of the time.

Maybe the fields should be passed as a param?

Signed-off-by: French Ben <me+git@frenchben.com>
