### PR TITLE
Update Member struct

### DIFF
--- a/member.go
+++ b/member.go
@@ -22,11 +22,14 @@ import (
 )
 
 type Member struct {
-	client                   *Client
-	Id                       string   `json:"id"`
-	AvatarHash               string   `json:"avatarHash"`
-	Bio                      string   `json:"bio"`
-	BioData                  string   `json:"bioData"`
+	client     *Client
+	Id         string `json:"id"`
+	AvatarHash string `json:"avatarHash"`
+	Bio        string `json:"bio"`
+	BioData    struct {
+		Emoji struct {
+		} `json:"emoji"`
+	} `json:"bioData"`
 	Confirmed                bool     `json:"confirmed"`
 	FullName                 string   `json:"fullName"`
 	IdPremOrgsAdmin          []string `json:"idPremOrgsAdmin"`

--- a/member.go
+++ b/member.go
@@ -27,8 +27,7 @@ type Member struct {
 	AvatarHash string `json:"avatarHash"`
 	Bio        string `json:"bio"`
 	BioData    struct {
-		Emoji struct {
-		} `json:"emoji"`
+		Emoji interface{} `json:"emoji,omitempty"`
 	} `json:"bioData"`
 	Confirmed                bool     `json:"confirmed"`
 	FullName                 string   `json:"fullName"`


### PR DESCRIPTION
It seems that Trello has updated the [`GET /1/members/[idMember or username]`](https://developers.trello.com/advanced-reference/member#get-1-members-idmember-or-username) API call. The `bioData` field is no longer returning a string for me. It's returning an object containing an `emoji` object. This pull request updates the `Member` struct to reflect that change, since member calls with go-trello were raising errors.

FYI: I'm very new at Go programming, so please let me know if there's something missing or that I could have done better :smile_cat: 
