### PR TITLE
Update Attachment struct

### DIFF
--- a/attachment.go
+++ b/attachment.go
@@ -21,11 +21,18 @@ type Attachment struct {
 	Id        string   `json:"id"`
 	Bytes     int      `json:"bytes"`
 	Date      string   `json:"date"`
-	EdgeColor []string `json:"edgeColor"`
+	EdgeColor string   `json:"edgeColor"`
 	IdMember  string   `json:"idMember"`
-	IsUpload  bool     `json:"idUpload"`
+	IsUpload  bool     `json:"isUpload"`
 	MimeType  []string `json:"mimeType"`
 	Name      string   `json:"name"`
-	Previews  []string `json:"previews"`
-	Url       string   `json:"url"`
+	Previews  []struct {
+		Width  int    `json:"width"`
+		Height int    `json:"height"`
+		Url    string `json:"url"`
+		Bytes  int    `json:"bytes"`
+		Id     string `json:"_id"`
+		Scaled bool   `json:"scaled"`
+	} `json:"previews"`
+	Url string `json:"url"`
 }


### PR DESCRIPTION
The Attachment struct seems to be out of date. This pull request updates the struct with a couple of fixes:
- The `edgeColor` field in Trello's API response is a single string, not an array of strings.
- There was a typo in the `isUpload` key name.
- The `previews` field is an array of objects, so I created the struct for those.

I tested this with a few different cards, fetching both the list and individual attachments, and it seems to be working well now.
