### PR TITLE
Fixes member struct, `LoginTypes` changes to `[]string`

### DIFF
--- a/member.go
+++ b/member.go
@@ -44,7 +44,7 @@ type Member struct {
 	IdBoards                 []string `json:"idBoards"`
 	IdBoardsPinned           []string `json:"idBoardsPinned"`
 	IdOrganizations          []string `json:"idOrganizations"`
-	LoginTypes               string   `json:"loginTypes"`
+	LoginTypes               []string `json:"loginTypes"`
 	NewEmail                 string   `json:"newEmail"`
 	OneTimeMessagesDismissed []string `json:"oneTimeMessagesDismissed"`
 	Prefs                    struct {


### PR DESCRIPTION
When the API token authorized with "account" scope, it seems that `LoginTypes` field is returning a string array, for example:

``` json
"loginTypes": ["password"],
```
