### PR TITLE
Added mechanism to pass arguments to client.

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 go-trello authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trello
+
+import "net/url"
+
+type Argument struct {
+	Name  string
+	Value string
+}
+
+func NewArgument(name, value string) *Argument {
+	return &Argument{
+		Name:  name,
+		Value: value,
+	}
+}
+
+func EncodeArgs(args []*Argument) string {
+	v := url.Values{}
+	for _, arg := range args {
+		v.Set(arg.Name, arg.Value)
+	}
+	return v.Encode()
+}

--- a/board.go
+++ b/board.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package trello
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type Board struct {
 	client   *Client
@@ -167,8 +170,13 @@ func (b *Board) MemberCards(IdMember string) (cards []Card, err error) {
 	return
 }
 
-func (b *Board) Actions() (actions []Action, err error) {
-	body, err := b.client.Get("/boards/" + b.Id + "/actions")
+func (b *Board) Actions(arg ...*Argument) (actions []Action, err error) {
+	ep := "/boards/" + b.Id + "/actions"
+	if query := EncodeArgs(arg); query != "" {
+		ep += "?" + query
+	}
+
+	body, err := b.client.Get(ep)
 	if err != nil {
 		return
 	}

--- a/board.go
+++ b/board.go
@@ -16,10 +16,7 @@ limitations under the License.
 
 package trello
 
-import (
-	"encoding/json"
-	"fmt"
-)
+import "encoding/json"
 
 type Board struct {
 	client   *Client


### PR DESCRIPTION
The first endpoint to use is boards, specifically `actions`resource that accept [various arguments](https://developers.trello.com/advanced-reference/board#get-1-boards-board-id-actions). If approved, will add other endpoints that accept arguments.
## Example

``` go
var args []*trello.Argument
args = append(args, trello.NewArgument("filter", "updateCard:idList"))
args = append(args, trello.NewArgument("since", "2016-02-01"))
args = append(args, trello.NewArgument("before", "2016-02-05"))

actions, err := board.Actions(args...) // query string will be ?before=2016-02-05&filter=updateCard%3AidList&since=2016-01-28
```

Resolves #15 
