### PR TITLE
The Card 'Pos' field is not an integer

### DIFF
--- a/card.go
+++ b/card.go
@@ -35,7 +35,7 @@ type Card struct {
 	IdMembersVoted        []string `json:"idMembersVoted"`
 	ManualCoverAttachment bool     `json:"manualCoverAttachment"`
 	Closed                bool     `json:"closed"`
-	Pos                   int      `json:"pos"`
+	Pos                   float64  `json:"pos"`
 	ShortLink             string   `json:"shortLink"`
 	DateLastActivity      string   `json:"dateLastActivity"`
 	ShortUrl              string   `json:"shortUrl"`

--- a/list.go
+++ b/list.go
@@ -77,7 +77,7 @@ func (l *List) AddCard(opts Card) (*Card, error) {
 	payload := url.Values{}
 	payload.Set("name", opts.Name)
 	payload.Set("desc", opts.Desc)
-	payload.Set("pos", strconv.Itoa(opts.Pos))
+	payload.Set("pos", strconv.FormatFloat(opts.Pos, 'g', -1, 64))
 	payload.Set("due", opts.Due)
 	payload.Set("idList", opts.IdList)
 	payload.Set("idMembers", strings.Join(opts.IdMembers, ","))


### PR DESCRIPTION
It is in fact a decimal. If two cards with consecutive integer pos have
a card placed between them the card in the middle with get a pos with a
.5. In fact on my board I have

```
  "pos": 61439.0625,
```
