### PR TITLE
Add parameterization for Actions call

### DIFF
--- a/card.go
+++ b/card.go
@@ -35,7 +35,7 @@ type Card struct {
 	IdMembersVoted        []string `json:"idMembersVoted"`
 	ManualCoverAttachment bool     `json:"manualCoverAttachment"`
 	Closed                bool     `json:"closed"`
-	Pos                   int      `json:"pos"`
+	Pos                   float32  `json:"pos"`
 	ShortLink             string   `json:"shortLink"`
 	DateLastActivity      string   `json:"dateLastActivity"`
 	ShortUrl              string   `json:"shortUrl"`

--- a/list.go
+++ b/list.go
@@ -69,6 +69,24 @@ func (l *List) Actions() (actions []Action, err error) {
 	return
 }
 
+func (l *List) Actions(arg ...*Argument) (actions []Action, err error) {
+	ep := "/lists/" + l.Id + "/actions"
+	if query := EncodeArgs(arg); query != "" {
+		ep += "?" + query
+	}
+
+	body, err := l.client.Get(ep)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(body, &actions)
+	for i := range actions {
+		actions[i].client = l.client
+	}
+	return
+}
+
 // AddCard creates with the attributes of the supplied Card struct
 // https://developers.trello.com/advanced-reference/card#post-1-cards
 func (l *List) AddCard(opts Card) (*Card, error) {

--- a/list.go
+++ b/list.go
@@ -56,19 +56,6 @@ func (l *List) Cards() (cards []Card, err error) {
 	return
 }
 
-func (l *List) Actions() (actions []Action, err error) {
-	body, err := l.client.Get("/lists/" + l.Id + "/actions")
-	if err != nil {
-		return
-	}
-
-	err = json.Unmarshal(body, &actions)
-	for i := range actions {
-		actions[i].client = l.client
-	}
-	return
-}
-
 func (l *List) Actions(arg ...*Argument) (actions []Action, err error) {
 	ep := "/lists/" + l.Id + "/actions"
 	if query := EncodeArgs(arg); query != "" {

--- a/list.go
+++ b/list.go
@@ -18,8 +18,8 @@ package trello
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 )
 
@@ -95,7 +95,7 @@ func (l *List) AddCard(opts Card) (*Card, error) {
 	payload := url.Values{}
 	payload.Set("name", opts.Name)
 	payload.Set("desc", opts.Desc)
-	payload.Set("pos", strconv.Itoa(opts.Pos))
+	payload.Set("pos", fmt.Sprintf("%f", opts.Pos))
 	payload.Set("due", opts.Due)
 	payload.Set("idList", opts.IdList)
 	payload.Set("idMembers", strings.Join(opts.IdMembers, ","))


### PR DESCRIPTION
I needed to pass arguments to the Action listing call, but it wasn't available at the time.  I've been using it for a while, and noticed that it isn't yet on this project.  Then I realized I never made a pull request...whoops.

Anyways, this just borrows from the existing varargs method that is used elsewhere, so it was a pretty minimal change.