### PR TITLE
Update GET /boards/ URL.

### DIFF
--- a/board.go
+++ b/board.go
@@ -68,7 +68,7 @@ type BoardBackground struct {
 }
 
 func (c *Client) Boards() (boards []Board, err error) {
-	body, err := c.Get("/boards/")
+	body, err := c.Get("/members/me/boards/")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Current call to `/boards/` is returning 404. Looks like the right way to
get all your boards is by calling `/members/me/boards`.
More info here: https://developers.trello.com/v1.0/reference#membersidboards